### PR TITLE
fix: Fix workspaces errors

### DIFF
--- a/packages/access/src/containers/Workspaces/WorkspaceBaseInfomation/index.tsx
+++ b/packages/access/src/containers/Workspaces/WorkspaceBaseInfomation/index.tsx
@@ -1,8 +1,8 @@
 import React, { useImperativeHandle, forwardRef, Ref, UIEvent } from 'react';
 import { debounce, merge } from 'lodash';
 import { FormItem, useForm, Input, Select, FormInstance } from '@kubed/components';
-import { Pattern, validator } from '@ks-console/shared';
-import { getDetailUrl } from '../../../stores/workspace';
+import { Pattern } from '@ks-console/shared';
+import { nameValidator } from '../../../stores/workspace';
 import { useUsers } from '../../../stores/user';
 import type { OriginalWorkspace, WorkspaceFormValues } from '../../../types/workspaces';
 
@@ -103,7 +103,8 @@ function WorkspaceBaseInfomation(
               if (value === 'workspaces') {
                 return Promise.reject(t('current name is not available'));
               }
-              return validator.nameValidator(getDetailUrl({ name: value }));
+
+              return nameValidator({ name: value });
             },
           },
         ]}

--- a/packages/access/src/containers/Workspaces/WorkspaceCreateModal/index.tsx
+++ b/packages/access/src/containers/Workspaces/WorkspaceCreateModal/index.tsx
@@ -33,7 +33,6 @@ export default function WorkspacesCreateModal({
   };
 
   const handleNext = (value: WorkspaceFormValues) => {
-    console.log(value);
     setBaseInfo(value);
     nextStep();
   };

--- a/packages/access/src/containers/Workspaces/index.tsx
+++ b/packages/access/src/containers/Workspaces/index.tsx
@@ -27,7 +27,7 @@ import { FormattedWorkspace, WorkspaceFormValues } from '../../types/workspaces'
 import WorkspacesCreateModal from './WorkspaceCreateModal';
 import WorkspacesEditModal from './WorkspaceEditModal';
 
-import { DescribleWrapper } from './styles';
+import { DescribleWrapper, FieldLable } from './styles';
 
 const { fetchList } = ClusterStore;
 
@@ -118,7 +118,7 @@ export default function Workspaces(): JSX.Element {
         icon: <Pen />,
         text: t('EDIT_INFORMATION'),
         action: 'edit',
-        show: !isSystemWorkspaces,
+        show: row => !isSystemWorkspaces(row),
         onClick: (e, record) => {
           setEditVisible(true);
           setEditWorkspace(record as FormattedWorkspace);
@@ -129,7 +129,7 @@ export default function Workspaces(): JSX.Element {
         icon: <Trash />,
         text: t('DELETE'),
         action: 'delete',
-        show: !isSystemWorkspaces,
+        show: row => !isSystemWorkspaces(row),
         onClick: (e, record) => {
           setWorkspaces([record as FormattedWorkspace]);
           setDeleteVisible(true);
@@ -164,11 +164,9 @@ export default function Workspaces(): JSX.Element {
       render: (value, row) => {
         return (
           <Field
-            value={getDisplayName(row)}
+            value={<Link to={value}>{getDisplayName(row)}</Link>}
             avatar={<Enterprise size={40} />}
-            label={row.description || '-'}
-            as={Link}
-            to={`/workspaces/${value}`}
+            label={<FieldLable>{row.description || '-'}</FieldLable>}
           />
         );
       },
@@ -214,6 +212,7 @@ export default function Workspaces(): JSX.Element {
         format={workspaceMapper}
         batchActions={renderBatchActions()}
         useStorageState={false}
+        placeholder={t('SEARCH_BY_NAME')}
         toolbarRight={renderTableActions()}
         disableRowSelect={isSystemWorkspaces}
         ref={tableRef}

--- a/packages/access/src/containers/Workspaces/styles.ts
+++ b/packages/access/src/containers/Workspaces/styles.ts
@@ -16,3 +16,13 @@ export const StyledForm = styled(Form)`
     }
   }
 `;
+
+export const FieldLable = styled.div`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-wrap: normal;
+  overflow: hidden;
+  font-weight: 400;
+  color: #79879c;
+  max-width: 300px;
+`;

--- a/packages/access/src/stores/workspace/index.ts
+++ b/packages/access/src/stores/workspace/index.ts
@@ -21,6 +21,7 @@ const getTenantUrl = (params = {}) =>
 
 export const getListUrl = (params: Record<string, any> = {}) =>
   params.cluster ? getResourceUrl() : getTenantUrl();
+
 export const getDetailUrl = (params: PathParams = {}) => `${getListUrl(params)}/${params.name}`;
 
 export const workspaceMapper = (item: OriginalWorkspace): FormattedWorkspace => {
@@ -54,6 +55,7 @@ export const workspaceMapper = (item: OriginalWorkspace): FormattedWorkspace => 
     _originData: getOriginData(item),
   };
 };
+
 export const deleteWorkspace = ({
   params = {},
   data,
@@ -98,4 +100,16 @@ export function useWorkspacesEditMutation(options?: { onSuccess?: () => void }) 
       onSuccess,
     },
   );
+}
+
+export async function nameValidator(params?: PathParams, query?: Record<string, any>) {
+  const resp: any = await request.get(getDetailUrl(params), {
+    query,
+    headers: {
+      // @ts-ignore
+      'x-check-exist': true,
+    },
+  });
+  if (resp.exist) return Promise.reject(t('WORKSPACE_NAME_EXISTS_DESC'));
+  return Promise.resolve();
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
