### PR TITLE
fix: devops 4.0 embed

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -501,6 +501,8 @@ client:
     name: "devops"
     children:
       - { name: pipelines, title: PIPELINE_PL, icon: application }
+      - { name: cd, title: CONTINUOUS_DEPLOYMENT_PL, icon: rocket, authKey: applications, requiredClusterVersion: v3.3.0 }
+      - { name: code-repo, title: CODE_REPO_PL, icon: code, authKey: gitrepositories, requiredClusterVersion: v3.3.0 }
       - name: management
         title: DEVOPS_PROJECT_SETTINGS
         icon: cogwheel

--- a/src/components/Modals/DevOpsCreate/index.jsx
+++ b/src/components/Modals/DevOpsCreate/index.jsx
@@ -82,7 +82,7 @@ export default class ProjectCreateModal extends React.Component {
       label: item.name,
       value: item.name,
       cluster: item,
-      disabled: !item.isReady || !get(item, 'configz.devops', false),
+      // disabled: !item.isReady || !get(item, 'configz.devops', false),
     }))
   }
 

--- a/src/core/global.js
+++ b/src/core/global.js
@@ -354,21 +354,33 @@ export default class GlobalValue {
     if (!this._cache_[`devops_${cluster}_${devops}_navs`]) {
       const navs = []
 
-      cloneDeep(globals.config.devopsNavs).forEach(nav => {
-        const filteredItems = nav.items.filter(item => {
-          item.cluster = cluster
-          return this.checkNavItem(item, params =>
-            this.hasPermission({ ...params, cluster, workspace, devops })
-          )
-        })
+      // cloneDeep(globals.config.devopsNavs).forEach(nav => {
+      //   const filteredItems = nav.items.filter(item => {
+      //     item.cluster = cluster
+      //     return this.checkNavItem(item, params =>
+      //       this.hasPermission({ ...params, cluster, workspace, devops })
+      //     )
+      //   })
 
-        if (!isEmpty(filteredItems)) {
-          this.checkClusterVersionRequired(filteredItems, cluster)
-          navs.push({ ...nav, items: filteredItems })
-        }
+      //   if (!isEmpty(filteredItems)) {
+      //     this.checkClusterVersionRequired(filteredItems, cluster)
+      //     navs.push({ ...nav, items: filteredItems })
+      //   }
 
-        this._cache_[`devops_${cluster}_${devops}_navs`] = navs
+      //   this._cache_[`devops_${cluster}_${devops}_navs`] = navs
+      // })
+      const clusterNavs = cloneDeep(globals.config.devopsNavs)
+      const filteredItems = clusterNavs.children.filter(item => {
+        item.cluster = cluster
+        return this.checkNavItem(item, params =>
+          this.hasPermission({ ...params, cluster, workspace, devops })
+        )
       })
+      if (!isEmpty(filteredItems)) {
+        this.checkClusterVersionRequired(filteredItems, cluster)
+        navs.push({ ...clusterNavs, children: filteredItems })
+      }
+      this._cache_[`devops_${cluster}_${devops}_navs`] = navs
     }
 
     return this._cache_[`devops_${cluster}_${devops}_navs`]

--- a/src/pages/devops/containers/Base/List/index.jsx
+++ b/src/pages/devops/containers/Base/List/index.jsx
@@ -59,11 +59,13 @@ class DevOpsListLayout extends Component {
     const { match, route, location } = this.props
     const { initializing, detail } = this.props.devopsStore
 
-    const navs = globals.app.getDevOpsNavs({
+    const navs1 = globals.app.getDevOpsNavs({
       devops: this.devops,
       cluster: this.cluster,
       workspace: this.workspace,
     })
+
+    const navs = [{ cate: '', items: navs1?.[0]?.children ?? [] }]
 
     const _navs = this.isHostCluster
       ? navs

--- a/src/stores/devops.js
+++ b/src/stores/devops.js
@@ -79,7 +79,7 @@ export default class DevOpsStore extends Base {
     `kapis/devops.kubesphere.io/v1alpha3${this.getPath(params)}/`
 
   getDevopsTenantUrl = params =>
-    `kapis/tenant.kubesphere.io/v1alpha2${this.getPath(params)}/devops`
+    `kapis/devops.kubesphere.io/v1alpha3${this.getPath(params)}/devops`
 
   getResourceUrl = params => `${this.getDevopsUrlV2(params)}`
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
